### PR TITLE
Move Remix to discontinued, add deemix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,10 @@ As you can see some infos and links are missing, if you have you are free to [co
 
 ## Contents
 - [Active Deezloader branches](#active-deezloader-branches)
-  - [Deezloader Remix](#deezloader-remix)
   - [Deezloader Android](#deezloader-android)
-  - [Deezloader Remix on Docker](#deezloader-remix-on-docker)
 - [Discontinued Deezloader branches](#discontinued-deezloader-branches)
+  - [Deezloader Remix](#deezloader-remix)
+  - [Deezloader Remix on Docker](#deezloader-remix-on-docker)
   - [Deezloader Remaster](#deezloader-remaster)
   - [Deezloader Reborn](#deezloader-reborn)
   - [Deezloader Reborn (Older)](#deezloader-reborn-older)
@@ -24,8 +24,27 @@ As you can see some infos and links are missing, if you have you are free to [co
 
 ## Active Deezloader branches
 
-### Deezloader Remix
+### Deezloader Android
 Status: **Active**<br>
+Available for: **Android**<br>
+Maintainer: [Nick80835](https://gitlab.com/Nick80835)
+
+Based on [Deezloader Remix](#deezloader-remix).<br>
+Thanks to the power of the recent [Node.js for Mobile Apps](https://github.com/janeasystems/nodejs-mobile), I'm glad to present to you the adapted version of Deezloader for Android! Now you can forget about the Termux method to run this tool; just install the apk and you're ready to go!
+
+#### Features
+- Same as the desktop version, but adapted for the small screens.
+
+#### Links
+**Repository** : https://gitlab.com/Nick80835/DeezLoader-Android<br>
+**Download** : https://gitlab.com/Nick80835/DeezLoader-Android/tree/master/Release<br>
+**News and Builds** : [@DeezloaderAndroid](https://t.me/DeezloaderAndroid)<br>
+**Help and Discussion** : [DeezloaderAndroidCommunity](https://t.me/joinchat/Ed1JxEfoci8sv2dVwTUQ3A)
+
+## Discontinued Deezloader branches
+
+### Deezloader Remix
+Status: **Discontinued**<br>
 Available for: **Windows**, **macOS**, **Linux**<br>
 Maintainer: [RemixDevs](https://notabug.org/RemixDevs)
 
@@ -59,27 +78,8 @@ With this app you can download songs, playlists and albums directly from Deezer'
 
 ---
 
-### Deezloader Android
-Status: **Active**<br>
-Available for: **Android**<br>
-Maintainer: [Nick80835](https://gitlab.com/Nick80835)
-
-Based on [Deezloader Remix](#deezloader-remix).<br>
-Thanks to the power of the recent [Node.js for Mobile Apps](https://github.com/janeasystems/nodejs-mobile), I'm glad to present to you the adapted version of Deezloader for Android! Now you can forget about the Termux method to run this tool; just install the apk and you're ready to go!
-
-#### Features
-- Same as the desktop version, but adapted for the small screens.
-
-#### Links
-**Repository** : https://gitlab.com/Nick80835/DeezLoader-Android<br>
-**Download** : https://gitlab.com/Nick80835/DeezLoader-Android/tree/master/Release<br>
-**News and Builds** : [@DeezloaderAndroid](https://t.me/DeezloaderAndroid)<br>
-**Help and Discussion** : [DeezloaderAndroidCommunity](https://t.me/joinchat/Ed1JxEfoci8sv2dVwTUQ3A)
-
----
-
 ### Deezloader Remix on Docker
-Status: **Active**<br>
+Status: **Discontinued**<br>
 Available for: **Docker**<br>
 Maintainer: [Bockiii](https://www.reddit.com/user/Bockiii)
 
@@ -92,7 +92,7 @@ Allows you to run Deezloader Remix on a Docker container. Useful for people who 
 **Repository** : https://github.com/Bockiii/deezloadermx-docker<br>
 **Docker Hub** : https://hub.docker.com/r/bocki/deezloaderrmx
 
-## Discontinued Deezloader branches
+---
 
 ### Deezloader Remaster
 Status: **Abandoned** *(Latest release 4.1.2)*<br>

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ As you can see some infos and links are missing, if you have you are free to [co
 
 ## Contents
 - [Active Deezloader branches](#active-deezloader-branches)
+  - [deemix](#deemix)
+  - [deemix on Docker](#deemix-on-docker)
   - [Deezloader Android](#deezloader-android)
 - [Discontinued Deezloader branches](#discontinued-deezloader-branches)
   - [Deezloader Remix](#deezloader-remix)
@@ -23,6 +25,32 @@ As you can see some infos and links are missing, if you have you are free to [co
   - [d-fi](#d-fi)
 
 ## Active Deezloader branches
+
+### deemix
+Status **Active**<br>
+Available for: **Python**<br>
+Maintainer: [RemixDev](https://notabug.org/RemixDev)
+
+#### Links
+**Repository** : https://notabug.org/RemixDev/deemix
+
+---
+
+### deemix on Docker
+Status: **Active**<br>
+Available for: **Docker**<br>
+Maintainer: [Bockiii](https://www.reddit.com/user/Bockiii)
+
+Deemix in a Docker container.
+
+#### Features
+Allows you to run Deemix on a Docker container. Useful for people who own a Media Server. Information regarding setting it up is present in the [README](https://github.com/Bockiii/deemix-docker/blob/master/README.md) of the project.
+
+#### Links
+**Repository** : https://github.com/Bockiii/deemix-docker<br>
+**Docker Hub** : https://hub.docker.com/r/bocki/deemix
+
+---
 
 ### Deezloader Android
 Status: **Active**<br>

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Thanks to the power of the recent [Node.js for Mobile Apps](https://github.com/j
 ## Discontinued Deezloader branches
 
 ### Deezloader Remix
-Status: **Discontinued**<br>
+Status: **Discontinued** *(Latest release 4.4.0)*<br>
 Available for: **Windows**, **macOS**, **Linux**<br>
 Maintainer: [RemixDevs](https://notabug.org/RemixDevs)
 


### PR DESCRIPTION
Deezloader Remix has been discontinued and the developer is working on a new downloader called deemix.

This PR moves Remix and Remix on Docker to the discontinued list and adds deemix and deemix on Docker.

No response from the Deezloader for Android dev yet, so I'm leaving it in the active list for now.